### PR TITLE
Script for opening and screenshotting apps in Kuiper

### DIFF
--- a/kuiper_gui_apps.sh
+++ b/kuiper_gui_apps.sh
@@ -5,32 +5,32 @@ cd /boot/ && echo analog | sudo -S mkdir -p gui-screenshots/
 
 screen --version
 echo analog | sudo -S apt-get install screen
-screen -S iio-osc -dm osc
+screen -S iio-osc -L -Logfile osc.txt -dm osc
 sleep 10
 scrot 'iio-oscilloscope_%Y-%m-%d.png' -e 'mv $f /boot/gui-screenshots/'
 sleep 2
 screen -X -S iio-osc kill
 sleep 2
-screen -S gnu -dm gnuradio-companion
+screen -S gnu -L -Logfile gnu-radio.txt -dm gnuradio-companion
 sleep 45
 scrot 'gnuradio_%Y-%m-%d.png' -e 'mv $f /boot/gui-screenshots/'
 sleep 2
 screen -X -S gnu kill
 sleep 2
-screen -S colorimeter -dm adi_colorimeter
+screen -S colorimeter -L -Logfile colorimeter.txt -dm adi_colorimeter
 sleep 10
 scrot 'adi-colorimeter_%Y-%m-%d.png' -e 'mv $f /boot/gui-screenshots/'
 sleep 2
 screen -X -S colorimeter kill
 sleep 2
-screen -S browser -dm chromium-browser
+screen -S browser -L -Logfile browser.txt -dm chromium-browser
 sleep 20
 scrot 'browser_%Y-%m-%d.png' -e 'mv $f /boot/gui-screenshots/'
 sleep 2
 screen -X -S browser kill
 sleep 2
 CMD='flatpak run org.adi.Scopy'
-screen -S scopy -dm $CMD
+screen -S scopy -L -Logfile scopy.txt -dm $CMD
 sleep 10
 scrot 'scopy_%Y-%m-%d.png' -e 'mv $f /boot/gui-screenshots/'
 sleep 2

--- a/kuiper_gui_apps.sh
+++ b/kuiper_gui_apps.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/bash
+
+# Make a gui-screenshots/ folder in boot/ if it doesn't exist
+cd /boot/ && echo analog | sudo -S mkdir -p gui-screenshots/
+
+screen --version
+echo analog | sudo -S apt-get install screen
+screen -S iio-osc -dm osc
+sleep 10
+scrot 'iio-oscilloscope_%Y-%m-%d.png' -e 'mv $f /boot/gui-screenshots/'
+sleep 2
+screen -X -S iio-osc kill
+sleep 2
+screen -S gnu -dm gnuradio-companion
+sleep 45
+scrot 'gnuradio_%Y-%m-%d.png' -e 'mv $f /boot/gui-screenshots/'
+sleep 2
+screen -X -S gnu kill
+sleep 2
+screen -S colorimeter -dm adi_colorimeter
+sleep 10
+scrot 'adi-colorimeter_%Y-%m-%d.png' -e 'mv $f /boot/gui-screenshots/'
+sleep 2
+screen -X -S colorimeter kill
+sleep 2
+screen -S browser -dm chromium-browser
+sleep 20
+scrot 'browser_%Y-%m-%d.png' -e 'mv $f /boot/gui-screenshots/'
+sleep 2
+screen -X -S browser kill
+sleep 2
+CMD='flatpak run org.adi.Scopy'
+screen -S scopy -dm $CMD
+sleep 10
+scrot 'scopy_%Y-%m-%d.png' -e 'mv $f /boot/gui-screenshots/'
+sleep 2
+screen -X -S scopy kill
+sleep 2

--- a/kuiper_gui_apps.sh
+++ b/kuiper_gui_apps.sh
@@ -1,38 +1,50 @@
 #!/usr/bin/bash
-
-# Make a gui-screenshots/ folder in boot/ if it doesn't exist
+echo 'Creating gui-screenshots/ in boot/'
 cd /boot/ && echo analog | sudo -S mkdir -p gui-screenshots/
+echo 'Creating gui-logs/ in boot/ and going back to original pwd...'
+echo analog | sudo -S mkdir -p gui-logs/ && cd
+pwd
+CMDS="osc gnuradio-companion adi_colorimeter chromium-browser scopy"
+for CMD in $CMDS
+  do
+    echo "Making a detached screen for $CMD..."
+    if [ "$CMD" == "scopy" ]
+    then
+      CMD="flatpak run org.adi.Scopy"
+      screen -S aaa -L -Logfile scopy.txt -dm $CMD
+    else
+      screen -S aaa -L -Logfile $CMD.txt -dm $CMD
+    fi
 
-screen --version
-echo analog | sudo -S apt-get install screen
-screen -S iio-osc -L -Logfile osc.txt -dm osc
-sleep 10
-scrot 'iio-oscilloscope_%Y-%m-%d.png' -e 'mv $f /boot/gui-screenshots/'
-sleep 2
-screen -X -S iio-osc kill
-sleep 2
-screen -S gnu -L -Logfile gnu-radio.txt -dm gnuradio-companion
-sleep 45
-scrot 'gnuradio_%Y-%m-%d.png' -e 'mv $f /boot/gui-screenshots/'
-sleep 2
-screen -X -S gnu kill
-sleep 2
-screen -S colorimeter -L -Logfile colorimeter.txt -dm adi_colorimeter
-sleep 10
-scrot 'adi-colorimeter_%Y-%m-%d.png' -e 'mv $f /boot/gui-screenshots/'
-sleep 2
-screen -X -S colorimeter kill
-sleep 2
-screen -S browser -L -Logfile browser.txt -dm chromium-browser
-sleep 20
-scrot 'browser_%Y-%m-%d.png' -e 'mv $f /boot/gui-screenshots/'
-sleep 2
-screen -X -S browser kill
-sleep 2
-CMD='flatpak run org.adi.Scopy'
-screen -S scopy -L -Logfile scopy.txt -dm $CMD
-sleep 10
-scrot 'scopy_%Y-%m-%d.png' -e 'mv $f /boot/gui-screenshots/'
-sleep 2
-screen -X -S scopy kill
-sleep 2
+    echo "Waiting for 65s..."
+    sleep 65
+
+    echo "Screenshotting..."
+    if [ "$CMD" == "osc" ]
+    then
+      echo analog | sudo -S scrot "iio-osc_%Y-%m-%d.png" -e 'mv $f /boot/gui-screenshots/'
+    elif [ "$CMD" == "flatpak run org.adi.Scopy" ]
+    then
+      echo analog | sudo -S scrot "scopy_%Y-%m-%d.png" -e 'mv $f /boot/gui-screenshots/'
+    else
+      echo analog | sudo -S scrot "${CMD}_%Y-%m-%d.png" -e 'mv $f /boot/gui-screenshots/' -u
+    fi
+
+    sleep 2
+    echo "Kill detached screen..."
+    screen -X -S aaa kill
+
+    if [ "$CMD" == "flatpak run org.adi.Scopy" ]
+    then
+      echo "Moving scopy.txt to /boot/gui-logs..."
+      echo analog | sudo -S cp scopy.txt /boot/gui-logs/ && cd
+      rm -rf scopy.txt && cd
+    else
+      echo "Moving ${CMD}.txt to /boot/gui-logs..."
+      echo analog | sudo -S cp $CMD.txt /boot/gui-logs/ && cd
+      rm -rf *.txt && cd
+    fi
+
+    echo "Done!"
+    sleep 2
+  done


### PR DESCRIPTION
This is the brief summary of kuiper_gui_apps.sh:

- List commands for opening apps in Kuiper; open apps
- Log stdout from terminal
- Screenshot using scrot
- Pipe screenshot to /boot/gui-screenshots/
- Move logs to /boot/gui-logs/